### PR TITLE
Switch zuul doc publishing template

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -2,4 +2,4 @@
     merge-mode: squash-merge
     default-branch: main
     templates:
-      - publish-otc-docs-int-pti
+      - publish-otc-docs-pti


### PR DESCRIPTION
HelpCenter docs are switched to dedicated template. Now fix this one
